### PR TITLE
[CPF-4840] Remove authentication on capability categories

### DIFF
--- a/src/services
+++ b/src/services
@@ -787,7 +787,7 @@ p({
   "serve":true,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)
-      .setAuthorize(true)
+      .setAuthorize(false)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("capabilityCategories")
       .setOf(foam.nanos.crunch.CapabilityCategory.getOwnClassInfo())
@@ -824,6 +824,7 @@ p({
   "description": "DAO responsible for storing capabilities' categories.",
   "serviceScript": """
     return new foam.dao.EasyDAO.Builder(x)
+      .setAuthorize(false)
       .setJournalType(foam.dao.JournalType.SINGLE_JOURNAL)
       .setJournalName("capabilityCategoryCapabilityJunction")
       .setOf(foam.nanos.crunch.CapabilityCategoryCapabilityJunction.getOwnClassInfo())


### PR DESCRIPTION
This was simpler than I thought - I didn't need to mess with permissions at all because there's no reason to do authorization checks on capability categories.