### PR TITLE
temporary cache for intercepting capabilities

### DIFF
--- a/src/foam/nanos/controller/ApplicationController.js
+++ b/src/foam/nanos/controller/ApplicationController.js
@@ -72,6 +72,7 @@ foam.CLASS({
     'notify',
     'pushMenu',
     'requestCapability',
+    'capabilityCache',
     'requestLogin',
     'signUpEnabled',
     'loginVariables',
@@ -242,7 +243,13 @@ foam.CLASS({
       factory: function() {
         return this.CrunchController.create();
       }
-
+    },
+    {
+      class: 'Map',
+      name: 'capabilityCache',
+      factory: function() {
+        return new Map();
+      }
     },
     {
       class: 'FObjectProperty',
@@ -441,6 +448,11 @@ foam.CLASS({
 
     function requestCapability(capabilityInfo) {
       var self = this;
+
+      capabilityInfo.capabilityOptions.forEach((c) => {
+        self.capabilityCache.set(c, false);
+      });
+
       self.capabilityAquired = false;
       self.capabilityCancelled = false;
       return new Promise(function(resolve, reject) {

--- a/src/foam/u2/crunch/CapabilityInterceptView.js
+++ b/src/foam/u2/crunch/CapabilityInterceptView.js
@@ -22,7 +22,8 @@ foam.CLASS({
     'capabilityAquired',
     'capabilityCancelled',
     'crunchController',
-    'stack'
+    'stack',
+    'capabilityCache'
   ],
 
   properties: [
@@ -51,6 +52,13 @@ foam.CLASS({
 
   methods: [
     function initE() {
+      this.capabilityOptions.forEach((c) => {
+        if ( this.capabilityCache.has(c) && this.capabilityCache.get(c) === true ) {
+          capabilityAquired = true;
+          this.stack.back();
+        }
+      });
+
       var view = this;
       this
         .addClass(this.myClass())
@@ -94,16 +102,26 @@ foam.CLASS({
     {
       name: 'cancel',
       code: function() {
-        this.stack.back();
+        // todo find which capability was applied for
+        this.capabilityOptions.forEach((c) => {
+          this.capabilityCache.set(c, true);
+        });
         if ( ! this.capabilityAquired ) this.capabilityCancelled = true;
+        this.stack.back();
       }
     },
     {
       name: 'aquire',
       label: 'return with capabilityAquired=true',
       code: function() {
+        // todo find which capability was applied for
         this.capabilityAquired = true;
+        this.capabilityOptions.forEach((c) => {
+          this.capabilityCache.set(c, true);
+        });
         this.stack.back();
+        alert('Your permissions has changed.');
+        location.reload();
       }
     }
   ]


### PR DESCRIPTION
- do not show intercepting capabilities that the user has already seen/applied for 
- they will show up again if user hard refresh
- on capabilityAquired, alert 'permission has changed' and reload 