### PR TITLE
[NP-1174] Move save in CapabilityWizardInfo to method

### DIFF
--- a/src/foam/nanos/crunch/ui/CapabilityWizardSection.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardSection.js
@@ -63,7 +63,7 @@ foam.CLASS({
     }
   ],
 
-  actions: [
+  methods: [
     {
       name: 'save',
       code: function() {
@@ -80,9 +80,6 @@ foam.CLASS({
         });
       }
     },
-  ],
-
-  methods: [
     {
       name: 'checkForUnusedProperties',
       code: function(sections, of) {


### PR DESCRIPTION
Going to write a quick story here 'cause this was a very educational bug fix.

When writing CapabilityWizardInfo the first time I made `save` an action. I thought it made sense because if this model was ever displayed in a ui it should have a `save` button.

Later, when writing the code for put ordering, `save` had to return a promise.

It turns out actions won't return a promise from the method invoked, but they do return a promise. It also turns out the promise an action call returns resolves before the promise its body returns, which was the cause of this bug.