### PR TITLE
Nulldataerror

### DIFF
--- a/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
+++ b/src/foam/nanos/crunch/UserCapabilityJunctionDAO.js
@@ -258,6 +258,8 @@ foam.CLASS({
       type: 'Boolean',
       documentation: `Check if prerequisites of a capability is fulfilled`,
       javaCode: `
+      boolean prerequisitesFulfilled = true;
+
       // for each of those junctions, check if the prerequisite is granted, if not, return false
       UserCapabilityJunction ucj = (UserCapabilityJunction) obj;
       for ( CapabilityCapabilityJunction ccJunction : ccJunctions ) {
@@ -268,16 +270,24 @@ foam.CLASS({
           EQ(UserCapabilityJunction.TARGET_ID, (String) ccJunction.getTargetId())
         ));
         if ( ucJunction == null || ucJunction.getStatus() != CapabilityJunctionStatus.GRANTED ) {
-          UserCapabilityJunction junction = new UserCapabilityJunction.Builder(x)
-            .setSourceId(ucj.getSourceId())
-            .setTargetId(ccJunction.getTargetId())
-            .build();
-          junction = (UserCapabilityJunction) ((DAO) x.get("userCapabilityJunctionDAO")).put_(x, junction);
-          if ( junction == null || junction.getStatus() != CapabilityJunctionStatus.GRANTED )
-            return false;
+          // if ucJunction is null, create a ucj and put to ucjDAO
+          // if ucJunction exists but is not granted, try to re-put the ucj
+          ucJunction = ucJunction == null ? 
+            new UserCapabilityJunction.Builder(x)
+              .setSourceId(ucj.getSourceId())
+              .setTargetId(ccJunction.getTargetId())
+              .build() :
+            ucJunction;
+          try {
+            ucJunction = (UserCapabilityJunction) ((DAO) x.get("userCapabilityJunctionDAO")).put_(x, ucJunction);
+          } catch ( RuntimeException e ) {
+            prerequisitesFulfilled = false;
+          }
+          if ( ucJunction == null || ucJunction.getStatus() != CapabilityJunctionStatus.GRANTED )
+            prerequisitesFulfilled = false;
         }
       }
-      return true;
+      return prerequisitesFulfilled;
       `
     },
     {

--- a/src/foam/nanos/crunch/ui/CapabilityWizardSection.js
+++ b/src/foam/nanos/crunch/ui/CapabilityWizardSection.js
@@ -67,10 +67,12 @@ foam.CLASS({
       name: 'data',
       factory: function () {
         if ( ! this.of ) return null;
-        if ( this.ucj === null ) {
-          return this.of.create({}, this);
-        }
-        return this.ucj.data;
+
+        var ret = this.of.create({}, this);
+        if ( this.ucj === null ) return ret;
+      
+        ret = Object.assign(ret, this.ucj.data);
+        return ret;
       }
     }
   ],

--- a/src/foam/nanos/crunch/ui/ScrollSectionWizardView.js
+++ b/src/foam/nanos/crunch/ui/ScrollSectionWizardView.js
@@ -57,7 +57,7 @@ foam.CLASS({
         var check = true;
         sectionsList.forEach((wizardSection) => {
           if ( ! wizardSection.of ) return true;
-          if ( wizardSection.data.errors_ ) {
+          if ( ! wizardSection.data || wizardSection.data.errors_ ) {
             check = false;
           }
         });


### PR DESCRIPTION
- fix null data when reopening unfinished onboarding
- made some changes to ucjdao such that when checkprereqs for one prereq return false, try to add the prereq and move on to try other prereqs as well if the add was unsuccessful, instead of returning false on the first fail.